### PR TITLE
Add flexible color picker widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ ElevatedButton(
   },
   child: Text("Custom iOS for all"),
 ),
+
+/// Using the picker widget directly
+CustomColorPicker(
+  onColorSelected: (color) {
+    setState(() => backgroundColor = color);
+  },
+),
 ```
 ## You have to
 Dispose the controller because the streamer, check the example in example/ folder

--- a/lib/custom_picker/custom_color_picker.dart
+++ b/lib/custom_picker/custom_color_picker.dart
@@ -1,0 +1,205 @@
+import 'package:flutter/material.dart';
+import 'package:ios_color_picker/custom_picker/pickers/slider_picker/slider_helper.dart';
+import 'package:ios_color_picker/custom_picker/pickers_selector_row.dart';
+import 'package:ios_color_picker/custom_picker/shared.dart';
+import 'package:ios_color_picker/custom_picker/localization.dart';
+import 'color_observer.dart';
+import 'helpers/cache_helper.dart';
+import 'history_colors.dart';
+
+/// The color picker content without any surrounding bottom sheet.
+class CustomColorPicker extends StatefulWidget {
+  final ValueChanged<Color> onColorSelected;
+  final IosColorPickerLocalizations localization;
+  final VoidCallback? onClose;
+
+  const CustomColorPicker({
+    super.key,
+    required this.onColorSelected,
+    this.localization = const IosColorPickerLocalizations(),
+    this.onClose,
+  });
+
+  @override
+  State<CustomColorPicker> createState() => _CustomColorPickerState();
+}
+
+class _CustomColorPickerState extends State<CustomColorPicker> {
+  @override
+  void initState() {
+    CacheHelper.init();
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      width: maxWidth(context),
+      height: 340 + componentsHeight(context),
+      decoration: BoxDecoration(
+        color: backgroundColor.withValues(alpha: 0.98),
+        borderRadius: const BorderRadius.all(Radius.circular(10)),
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.start,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 0, 8, 2),
+            child: Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const SizedBox(width: 40),
+                Text(
+                  widget.localization.colorsTitle,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        fontSize: 17,
+                        color: Colors.white,
+                        fontWeight: FontWeight.w700,
+                      ),
+                ),
+                if (widget.onClose != null)
+                  IconButton(
+                    highlightColor: Colors.transparent,
+                    onPressed: widget.onClose,
+                    icon: Container(
+                      padding: const EdgeInsets.all(4),
+                      decoration: const BoxDecoration(
+                        color: Color(0xff3A3A3B),
+                        shape: BoxShape.circle,
+                      ),
+                      child: const Icon(
+                        Icons.close_rounded,
+                        color: Color(0xffA4A4AA),
+                        size: 20,
+                      ),
+                    ),
+                  )
+                else
+                  const SizedBox(width: 40),
+              ],
+            ),
+          ),
+          PickersSelectorRow(
+            onColorChanged: widget.onColorSelected,
+            localization: widget.localization,
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 17.0),
+            child: Text(
+              widget.localization.opacityLabel,
+              style: Theme.of(context).textTheme.titleLarge?.copyWith(
+                    fontSize: 13,
+                    color: Colors.white.withOpacity(0.6),
+                  ),
+            ),
+          ),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Expanded(
+                child: Padding(
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 12.0, vertical: 2),
+                  child: SizedBox(
+                    height: 36.0,
+                    child: ValueListenableBuilder<Color>(
+                      valueListenable: colorController,
+                      builder: (context, color, child) {
+                        return ColorPickerSlider(
+                            TrackType.alpha, HSVColor.fromColor(color),
+                            small: false, (v) {
+                          colorController.updateOpacity(v.alpha);
+                          widget.onColorSelected(colorController.value);
+                        });
+                      },
+                    ),
+                  ),
+                ),
+              ),
+              Container(
+                height: 36,
+                width: 77,
+                margin: const EdgeInsets.only(right: 16, left: 16),
+                alignment: Alignment.center,
+                decoration: const BoxDecoration(
+                  color: valueColor,
+                  borderRadius: BorderRadius.all(Radius.circular(8)),
+                ),
+                child: ValueListenableBuilder<Color>(
+                  valueListenable: colorController,
+                  builder: (context, color, child) {
+                    final int alpha = (color.a * 100).toInt();
+                    return Text(
+                      "$alpha%",
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                            fontSize: 16,
+                            letterSpacing: 0.6,
+                            color: Colors.white,
+                            fontWeight: FontWeight.w600,
+                          ),
+                    );
+                  },
+                ),
+              )
+            ],
+          ),
+          Divider(
+            height: 44,
+            thickness: 0.2,
+            indent: 17,
+            endIndent: 17,
+          ),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Stack(
+                children: [
+                  Container(
+                    height: 78,
+                    width: 78,
+                    clipBehavior: Clip.antiAliasWithSaveLayer,
+                    margin: const EdgeInsets.only(left: 16),
+                    decoration: const BoxDecoration(
+                      borderRadius: BorderRadius.all(Radius.circular(10)),
+                    ),
+                    child: Transform.scale(
+                      scale: 1.5,
+                      child: Transform.rotate(
+                        angle: 0.76,
+                        child: Row(
+                          children: const [
+                            Expanded(child: ColoredBox(color: Colors.white)),
+                            Expanded(child: ColoredBox(color: Colors.black)),
+                          ],
+                        ),
+                      ),
+                    ),
+                  ),
+                  ValueListenableBuilder<Color>(
+                    valueListenable: colorController,
+                    builder: (context, color, child) {
+                      return Container(
+                        height: 78,
+                        width: 78,
+                        margin: const EdgeInsets.only(left: 16),
+                        decoration: BoxDecoration(
+                          borderRadius: const BorderRadius.all(Radius.circular(10)),
+                          color: color,
+                        ),
+                      );
+                    },
+                  ),
+                ],
+              ),
+              HistoryColors(
+                onColorChanged: widget.onColorSelected,
+                localization: widget.localization,
+              )
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/custom_picker/history_colors.dart
+++ b/lib/custom_picker/history_colors.dart
@@ -6,10 +6,16 @@ import 'package:super_tooltip/super_tooltip.dart';
 import 'color_observer.dart';
 import 'extensions.dart';
 import 'helpers/cache_helper.dart';
+import 'localization.dart';
 
 class HistoryColors extends StatefulWidget {
   final ValueChanged<Color> onColorChanged;
-  const HistoryColors({super.key, required this.onColorChanged});
+  final IosColorPickerLocalizations localization;
+  const HistoryColors({
+    super.key,
+    required this.onColorChanged,
+    this.localization = const IosColorPickerLocalizations(),
+  });
 
   @override
   State<HistoryColors> createState() => _HistoryColorsState();
@@ -170,7 +176,7 @@ class _HistoryColorsState extends State<HistoryColors> {
                           padding: const EdgeInsets.symmetric(
                               vertical: 8, horizontal: 12),
                           child: Text(
-                            "Delete",
+                            widget.localization.deleteTooltip,
                             style: Theme.of(context)
                                 .textTheme
                                 .bodyMedium

--- a/lib/custom_picker/ios_color_picker.dart
+++ b/lib/custom_picker/ios_color_picker.dart
@@ -1,31 +1,20 @@
 import 'package:flutter/material.dart';
-import 'package:ios_color_picker/custom_picker/pickers/slider_picker/slider_helper.dart';
-import 'package:ios_color_picker/custom_picker/pickers_selector_row.dart';
 import 'package:ios_color_picker/custom_picker/shared.dart';
-import 'color_observer.dart';
-import 'helpers/cache_helper.dart';
-import 'history_colors.dart';
+import 'localization.dart';
+import 'custom_color_picker.dart';
 
 ///Returns iOS Style color Picker
-class IosColorPicker extends StatefulWidget {
+/// Wrapper that displays [CustomColorPicker] inside a modal style layout.
+class IosColorPicker extends StatelessWidget {
   const IosColorPicker({
     super.key,
     required this.onColorSelected,
+    this.localization = const IosColorPickerLocalizations(),
   });
 
   ///returns the selected color
   final ValueChanged<Color> onColorSelected;
-
-  @override
-  State<IosColorPicker> createState() => _IosColorPickerState();
-}
-
-class _IosColorPickerState extends State<IosColorPicker> {
-  @override
-  void initState() {
-    CacheHelper.init();
-    super.initState();
-  }
+  final IosColorPickerLocalizations localization;
 
   @override
   Widget build(BuildContext context) {
@@ -41,187 +30,10 @@ class _IosColorPickerState extends State<IosColorPicker> {
             ),
           ),
         ),
-        Container(
-          width: maxWidth(context),
-          height: 340 + componentsHeight(context),
-          decoration: BoxDecoration(
-            color: backgroundColor.withValues(alpha: 0.98),
-            borderRadius: BorderRadius.only(
-              topRight: Radius.circular(10),
-              topLeft: Radius.circular(10),
-            ),
-          ),
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.start,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Padding(
-                padding: const EdgeInsets.fromLTRB(
-                  16,
-                  0,
-                  8,
-                  2,
-                ),
-                child: Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    const SizedBox(
-                      width: 40,
-                    ),
-                    Text(
-                      'Colors',
-                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                          fontSize: 17,
-                          color: Colors.white,
-                          fontWeight: FontWeight.w700),
-                    ),
-                    IconButton(
-                      highlightColor: Colors.transparent,
-                      onPressed: () => Navigator.pop(context),
-                      icon: Container(
-                        padding: EdgeInsets.all(4),
-                        decoration: BoxDecoration(
-                            color: Color(0xff3A3A3B), shape: BoxShape.circle),
-                        child: Icon(
-                          Icons.close_rounded,
-                          color: Color(0xffA4A4AA),
-                          size: 20,
-                        ),
-                      ),
-                    ),
-                  ],
-                ),
-              ),
-              PickersSelectorRow(
-                onColorChanged: widget.onColorSelected,
-              ),
-
-              ///ALL
-              Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 17.0),
-                child: Text(
-                  'OPACITY',
-                  style: Theme.of(context).textTheme.titleLarge?.copyWith(
-                      fontSize: 13, color: Colors.white.withValues(alpha: 0.6)),
-                ),
-              ),
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  Expanded(
-                    child: Padding(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 12.0, vertical: 2),
-                      child: SizedBox(
-                        height: 36.0,
-                        child: ValueListenableBuilder<Color>(
-                          valueListenable: colorController,
-                          builder: (context, color, child) {
-                            return ColorPickerSlider(
-                                TrackType.alpha, HSVColor.fromColor(color),
-                                small: false, (v) {
-                              colorController.updateOpacity(v.alpha);
-                              widget.onColorSelected(colorController.value);
-                            });
-                          },
-                        ),
-                      ),
-                    ),
-                  ),
-                  Container(
-                    height: 36,
-                    width: 77,
-                    margin: const EdgeInsets.only(right: 16, left: 16),
-                    alignment: Alignment.center,
-                    decoration: const BoxDecoration(
-                        color: valueColor,
-                        borderRadius: BorderRadius.all(Radius.circular(8))),
-                    child: ValueListenableBuilder<Color>(
-                      valueListenable: colorController,
-                      builder: (context, color, child) {
-                        int alpha = (color.a * 100).toInt();
-                        return Text(
-                          "$alpha%",
-                          style: Theme.of(context)
-                              .textTheme
-                              .bodySmall
-                              ?.copyWith(
-                                  fontSize: 16,
-                                  letterSpacing: 0.6,
-                                  color: Colors.white,
-                                  fontWeight: FontWeight.w600),
-                        );
-                      },
-                    ),
-                  )
-                ],
-              ),
-              // const SizedBox(
-              //   height: 44,
-              // ),
-              Divider(
-                height: 44,
-                thickness: 0.2,
-                indent: 17,
-                endIndent: 17,
-              ),
-              Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  Stack(
-                    children: [
-                      Container(
-                        height: 78,
-                        width: 78,
-                        clipBehavior: Clip.antiAliasWithSaveLayer,
-                        margin: const EdgeInsets.only(
-                          left: 16,
-                        ),
-                        decoration: const BoxDecoration(
-                          borderRadius: BorderRadius.all(
-                            Radius.circular(10),
-                          ),
-                        ),
-                        child: Transform.scale(
-                          scale: 1.5,
-                          child: Transform.rotate(
-                            angle: 0.76,
-                            child: Row(
-                              children: [
-                                Expanded(child: Container(color: Colors.white)),
-                                Expanded(child: Container(color: Colors.black)),
-                              ],
-                            ),
-                          ),
-                        ),
-                      ),
-                      ValueListenableBuilder<Color>(
-                        valueListenable: colorController,
-                        builder: (context, color, child) {
-                          return Container(
-                            height: 78,
-                            width: 78,
-                            margin: const EdgeInsets.only(
-                              left: 16,
-                            ),
-                            decoration: BoxDecoration(
-                                borderRadius: const BorderRadius.all(
-                                  Radius.circular(10),
-                                ),
-                                color: color),
-                          );
-                        },
-                      ),
-                    ],
-                  ),
-                  HistoryColors(
-                    onColorChanged: widget.onColorSelected,
-                  )
-                ],
-              ),
-            ],
-          ),
+        CustomColorPicker(
+          localization: localization,
+          onColorSelected: onColorSelected,
+          onClose: () => Navigator.pop(context),
         ),
       ],
     );

--- a/lib/custom_picker/localization.dart
+++ b/lib/custom_picker/localization.dart
@@ -1,0 +1,19 @@
+class IosColorPickerLocalizations {
+  final String colorsTitle;
+  final String opacityLabel;
+  final String gridTab;
+  final String spectrumTab;
+  final String slidersTab;
+  final String deleteTooltip;
+  final String displayP3Label;
+
+  const IosColorPickerLocalizations({
+    this.colorsTitle = 'Colors',
+    this.opacityLabel = 'OPACITY',
+    this.gridTab = 'Grid',
+    this.spectrumTab = 'Spectrum',
+    this.slidersTab = 'Sliders',
+    this.deleteTooltip = 'Delete',
+    this.displayP3Label = 'Display P3 Hex Color #',
+  });
+}

--- a/lib/custom_picker/pickers/slider_picker/slider_picker.dart
+++ b/lib/custom_picker/pickers/slider_picker/slider_picker.dart
@@ -3,6 +3,7 @@ import 'package:ios_color_picker/custom_picker/extensions.dart';
 import 'package:ios_color_picker/custom_picker/pickers/slider_picker/slider_helper.dart';
 import '../../shared.dart';
 import '../../utils.dart';
+import '../../localization.dart';
 
 class SlidePicker extends StatefulWidget {
   const SlidePicker({
@@ -29,6 +30,7 @@ class SlidePicker extends StatefulWidget {
     this.indicatorAlignmentEnd = const Alignment(1.0, 3.0),
     this.displayThumbColor = true,
     this.indicatorBorderRadius = const BorderRadius.all(Radius.zero),
+    this.localization = const IosColorPickerLocalizations(),
   });
 
   final Color pickerColor;
@@ -48,6 +50,7 @@ class SlidePicker extends StatefulWidget {
   final AlignmentGeometry indicatorAlignmentEnd;
   final bool displayThumbColor;
   final BorderRadius indicatorBorderRadius;
+  final IosColorPickerLocalizations localization;
 
   @override
   State<StatefulWidget> createState() => _SlidePickerState();
@@ -188,7 +191,7 @@ class _SlidePickerState extends State<SlidePicker> {
             mainAxisAlignment: MainAxisAlignment.end,
             children: [
               Text(
-                "Display P3 Hex Color #",
+                widget.localization.displayP3Label,
                 style: Theme.of(context)
                     .textTheme
                     .titleMedium

--- a/lib/custom_picker/pickers_selector_row.dart
+++ b/lib/custom_picker/pickers_selector_row.dart
@@ -6,9 +6,16 @@ import 'package:ios_color_picker/custom_picker/shared.dart';
 import 'color_observer.dart';
 import 'helpers/cache_helper.dart';
 
+import 'localization.dart';
+
 class PickersSelectorRow extends StatefulWidget {
   final ValueChanged<Color> onColorChanged;
-  const PickersSelectorRow({super.key, required this.onColorChanged});
+  final IosColorPickerLocalizations localization;
+  const PickersSelectorRow({
+    super.key,
+    required this.onColorChanged,
+    this.localization = const IosColorPickerLocalizations(),
+  });
 
   @override
   State<PickersSelectorRow> createState() => _PickersSelectorRowState();
@@ -16,10 +23,15 @@ class PickersSelectorRow extends StatefulWidget {
 
 class _PickersSelectorRowState extends State<PickersSelectorRow> {
   int typeIndex = 0;
-  final List<String> typeText = ["Grid", "Spectrum", "Sliders"];
+  late final List<String> typeText;
 
   @override
   void initState() {
+    typeText = [
+      widget.localization.gridTab,
+      widget.localization.spectrumTab,
+      widget.localization.slidersTab,
+    ];
     (CacheHelper().getData(key: "selector_index") as Future<dynamic>)
         .then((onValue) {
       if (onValue != null && onValue is int) {
@@ -178,6 +190,7 @@ class _PickersSelectorRowState extends State<PickersSelectorRow> {
                 return SlidePicker(
                   enableAlpha: false,
                   pickerColor: color,
+                  localization: widget.localization,
                   onColorChanged: (Color value) {
                     colorController.updateColor(value);
                     widget.onColorChanged(colorController.value);

--- a/lib/ios_color_picker.dart
+++ b/lib/ios_color_picker.dart
@@ -1,0 +1,4 @@
+export 'show_ios_color_picker.dart';
+export 'custom_picker/ios_color_picker.dart' show IosColorPicker;
+export 'custom_picker/custom_color_picker.dart' show CustomColorPicker;
+export 'custom_picker/localization.dart';

--- a/lib/show_ios_color_picker.dart
+++ b/lib/show_ios_color_picker.dart
@@ -4,7 +4,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'custom_picker/color_observer.dart';
 import 'custom_picker/ios_color_picker.dart';
+import 'custom_picker/custom_color_picker.dart';
 import 'custom_picker/extensions.dart';
+import 'custom_picker/localization.dart';
 import 'native_picker/ios_color_picker_platform_interface.dart';
 
 ///Don't forget to Dispose the controller
@@ -53,6 +55,7 @@ class IOSColorPickerController {
     required BuildContext context,
     required ValueChanged<Color> onColorChanged,
     Color? startingColor,
+    IosColorPickerLocalizations localization = const IosColorPickerLocalizations(),
   }) async {
     colorController = ColorController(startingColor ?? selectedColor);
     return showModalBottomSheet(
@@ -62,12 +65,30 @@ class IOSColorPickerController {
         context: context,
         builder: (context) {
           return IosColorPicker(
+            localization: localization,
             onColorSelected: (value) {
               selectedColor = value;
               onColorChanged(selectedColor);
             },
           );
         });
+  }
+
+  /// Returns the color picker widget so you can embed it anywhere.
+  Widget iosColorPickerWidget({
+    required ValueChanged<Color> onColorChanged,
+    Color? startingColor,
+    IosColorPickerLocalizations localization =
+        const IosColorPickerLocalizations(),
+  }) {
+    colorController = ColorController(startingColor ?? selectedColor);
+    return CustomColorPicker(
+      localization: localization,
+      onColorSelected: (value) {
+        selectedColor = value;
+        onColorChanged(selectedColor);
+      },
+    );
   }
 
   /// Cancel the color subscription


### PR DESCRIPTION
## Summary
- separate color picker UI into `CustomColorPicker`
- simplify `IosColorPicker` to wrap `CustomColorPicker` inside a modal
- allow embedding with `iosColorPickerWidget`
- document how to use the widget directly

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b8e37f46c83249ca31eb14ac400da