### PR TITLE
Add initColor param to color picker bottom sheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ ElevatedButton(
 
 /// Using the picker widget directly
 CustomColorPicker(
+  initColor: backgroundColor,
   onColorSelected: (color) {
     setState(() => backgroundColor = color);
   },

--- a/lib/custom_picker/custom_color_picker.dart
+++ b/lib/custom_picker/custom_color_picker.dart
@@ -12,12 +12,14 @@ class CustomColorPicker extends StatefulWidget {
   final ValueChanged<Color> onColorSelected;
   final IosColorPickerLocalizations localization;
   final VoidCallback? onClose;
+  final Color? initColor;
 
   const CustomColorPicker({
     super.key,
     required this.onColorSelected,
     this.localization = const IosColorPickerLocalizations(),
     this.onClose,
+    this.initColor,
   });
 
   @override
@@ -28,6 +30,9 @@ class _CustomColorPickerState extends State<CustomColorPicker> {
   @override
   void initState() {
     CacheHelper.init();
+    if (widget.initColor != null) {
+      colorController = ColorController(widget.initColor!);
+    }
     super.initState();
   }
 

--- a/lib/custom_picker/ios_color_picker.dart
+++ b/lib/custom_picker/ios_color_picker.dart
@@ -10,11 +10,13 @@ class IosColorPicker extends StatelessWidget {
     super.key,
     required this.onColorSelected,
     this.localization = const IosColorPickerLocalizations(),
+    this.initColor,
   });
 
   ///returns the selected color
   final ValueChanged<Color> onColorSelected;
   final IosColorPickerLocalizations localization;
+  final Color? initColor;
 
   @override
   Widget build(BuildContext context) {
@@ -34,6 +36,7 @@ class IosColorPicker extends StatelessWidget {
           localization: localization,
           onColorSelected: onColorSelected,
           onClose: () => Navigator.pop(context),
+          initColor: initColor,
         ),
       ],
     );

--- a/lib/show_ios_color_picker.dart
+++ b/lib/show_ios_color_picker.dart
@@ -55,9 +55,9 @@ class IOSColorPickerController {
     required BuildContext context,
     required ValueChanged<Color> onColorChanged,
     Color? startingColor,
-    IosColorPickerLocalizations localization = const IosColorPickerLocalizations(),
+    IosColorPickerLocalizations localization =
+        const IosColorPickerLocalizations(),
   }) async {
-    colorController = ColorController(startingColor ?? selectedColor);
     return showModalBottomSheet(
         backgroundColor: Colors.transparent,
         barrierColor: Colors.black26,
@@ -66,6 +66,7 @@ class IOSColorPickerController {
         builder: (context) {
           return IosColorPicker(
             localization: localization,
+            initColor: startingColor ?? selectedColor,
             onColorSelected: (value) {
               selectedColor = value;
               onColorChanged(selectedColor);
@@ -81,9 +82,9 @@ class IOSColorPickerController {
     IosColorPickerLocalizations localization =
         const IosColorPickerLocalizations(),
   }) {
-    colorController = ColorController(startingColor ?? selectedColor);
     return CustomColorPicker(
       localization: localization,
+      initColor: startingColor ?? selectedColor,
       onColorSelected: (value) {
         selectedColor = value;
         onColorChanged(selectedColor);


### PR DESCRIPTION
## Summary
- support initial colors in `CustomColorPicker`
- plumb initColor through `IosColorPicker` and controller helpers
- document `initColor` usage

## Testing
- `dart test` *(fails: `dart` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68776dcb9024832499e00ca914135ca8